### PR TITLE
Add headers_json field

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -390,6 +390,9 @@
             "headers": {
               "$ref": "#/definitions/http_headers"
             },
+            "headers_json": {
+              "$ref": "#/definitions/http_headers_json"
+            },
             "host": {
               "$ref": "#/definitions/http_host"
             },
@@ -428,6 +431,9 @@
             "headers": {
               "$ref": "#/definitions/http_headers"
             },
+            "headers_json": {
+              "$ref": "#/definitions/http_headers_json"
+            },
             "status": {
               "$ref": "#/definitions/http_status"
             },
@@ -453,6 +459,9 @@
             },
             "headers": {
               "$ref": "#/definitions/http_headers"
+            },
+            "headers_json": {
+              "$ref": "#/definitions/http_headers_json"
             },
             "method": {
               "$ref": "#/definitions/http_method"
@@ -488,6 +497,9 @@
             },
             "headers": {
               "$ref": "#/definitions/http_headers"
+            },
+            "headers_json": {
+              "$ref": "#/definitions/http_headers_json"
             },
             "request_id": {
               "$ref": "#/definitions/http_request_id"
@@ -601,9 +613,14 @@
     },
     "http_headers": {
       "type": "object",
-      "description": "An object representing HTTP headers.",
+      "description": "An object representing *select* HTTP headers that need to be searched or graphed.",
       "minProperties": 1,
       "maxProperties": 100
+    },
+    "http_headers_json": {
+      "type": "string",
+      "description": "A string representing *all* HTTP headers, this is solely used for request inspection.",
+      "maxLEngth": 8192
     },
     "http_host": {
       "type": "string",


### PR DESCRIPTION
Instead of defaulting to sending every header field, the libraries will now default to sending a string / JSON representation of the headers. This ensures that the schema does not get out of hand. The libraries will be updated to allow a white list of headers to accept and structure in the original `headers` field.