### PR TITLE
Restructure resource samples

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -270,29 +270,6 @@
       "minProperties": 1,
       "additionalProperties": false,
       "properties": {
-        "cpu_sample": {
-          "type": "object",
-          "description": "A sample of the current server processor usage.",
-          "minProperties": 1,
-          "additionalProperties": false,
-          "properties": {
-            "load_avg_1m": {
-              "type": "number",
-              "description": "The load average for the processor in the last 1 minute. This reflects the number of CPU tasks that are in the ready queue (i.e. waiting to be processed).",
-              "minimum": 0
-            },
-            "load_avg_5m": {
-              "type": "number",
-              "description": "The load average for the processor in the last 5 minutes. This reflects the number of CPU tasks that are in the ready queue (i.e. waiting to be processed).",
-              "minimum": 0
-            },
-            "load_avg_15m": {
-              "type": "number",
-              "description": "The load average for the processor in the last 10 minutes. This reflects the number of CPU tasks that are in the ready queue (i.e. waiting to be processed).",
-              "minimum": 0
-            }
-          }
-        },
         "controller_call": {
           "type": "object",
           "description": "Represents the calling of a controller, typically logged immediately after the request is routed.",
@@ -512,46 +489,123 @@
             }
           }
         },
-        "memory_sample": {
+        "resource_sample": {
           "type": "object",
-          "description": "A sample of the current server memory usage.",
+          "description": "Represents a resource usage sample for a target server, application, or both.",
           "minProperties": 1,
-          "additionalProperties": false,
           "properties": {
-            "cache_mb": {
-              "type": "number",
-              "description": "The portion of the memory used for disk cache.",
-              "minimum": 0
+            "cpu": {
+              "type": "object",
+              "description": "A sample of the current server processor usage.",
+              "required": ["load_avg_1m"],
+              "minProperties": 1,
+              "additionalProperties": false,
+              "properties": {
+                "load_avg_1m": {
+                  "type": "number",
+                  "description": "The load average for the processor in the last 1 minute. This reflects the number of CPU tasks that are in the ready queue (i.e. waiting to be processed).",
+                  "minimum": 0
+                },
+                "load_avg_5m": {
+                  "type": "number",
+                  "description": "The load average for the processor in the last 5 minutes. This reflects the number of CPU tasks that are in the ready queue (i.e. waiting to be processed).",
+                  "minimum": 0
+                },
+                "load_avg_15m": {
+                  "type": "number",
+                  "description": "The load average for the processor in the last 10 minutes. This reflects the number of CPU tasks that are in the ready queue (i.e. waiting to be processed).",
+                  "minimum": 0
+                }
+              }
             },
-            "limit_mb": {
-              "type": "number",
-              "description": "The maximum amount of memory, limit, that can be used before swap is used.",
-              "minimum": 0
+            "database": {
+              "type": "object",
+              "description": "A sample of various database and local data server statistics.",
+              "required": ["db_size", "active_connections"],
+              "minProperties": 1,
+              "additionalProperties": false,
+              "properties": {
+                "db_size": {
+                  "type": "integer",
+                  "description": "The number of bytes contained in the database. This includes all table and index data on disk, including database bloat.",
+                  "minimum": 0
+                },
+                "tables": {
+                  "type": "integer",
+                  "description": "The number of tables in the database",
+                  "minimum": 0
+                },
+                "active_connections": {
+                  "type": "integer",
+                  "description": "The number of active connections established with the database.",
+                  "minimum": 0
+                },
+                "current_transaction": {
+                  "type": "string",
+                  "description": "The current transaction ID, which can be used to track writes over time.",
+                  "minLength": 1,
+                  "maxLength": 256
+                },
+                "index_cache_hit_rate": {
+                  "type": "number",
+                  "description": "Ratio of queries that used an index (instead of only sequential scans), rounded to five decimal points.",
+                  "minimum": 0
+                },
+                "table_cache_hit_rate": {
+                  "type": "number",
+                  "description": "Ratio of table lookups served from shared buffer cache, rounded to five decimal points.",
+                  "minimum": 0
+                },
+                "waiting_connections": {
+                  "type": "integer",
+                  "description": "Number of connections waiting on a lock to be acquired.",
+                  "minimum": 0
+                }
+              }
             },
-            "pgpgin": {
-              "type": "number",
-              "description": "The cumulative total of the pages read from disk. Sudden high variations on this number can indicate short duration spikes in swap usage. The other memory related metrics are point in time snapshots and can miss short spikes.",
-              "minimum": 0
-            },
-            "pgpgout": {
-              "type": "number",
-              "description": "The cumulative total of the pages written to disk. Sudden high variations on this number can indicate short duration spikes in swap usage. The other memory related metrics are point in time snapshots and can miss short spikes.",
-              "minimum": 0
-            },
-            "rss_mb": {
-              "type": "number",
-              "description": "The portion of the memory being used by the target application.",
-              "minimum": 0
-            },
-            "swap_mb": {
-              "type": "number",
-              "description": "The portion of the memory stored on disk. Swap usually indicates a shortage of memory.",
-              "minimum": 0
-            },
-            "total_mb": {
-              "type": "number",
-              "description": "The sum of the rss, cache, and swap that equals the total memory being used.",
-              "minimum": 0
+            "memory": {
+              "type": "object",
+              "description": "A sample of a server's memory usage.",
+              "required": ["limit_mb", "total_mb"],
+              "minProperties": 1,
+              "additionalProperties": false,
+              "properties": {
+                "cache_mb": {
+                  "type": "number",
+                  "description": "The portion of the memory used for disk cache.",
+                  "minimum": 0
+                },
+                "limit_mb": {
+                  "type": "number",
+                  "description": "The maximum amount of memory, limit, that can be used before swap is used.",
+                  "minimum": 0
+                },
+                "pgpgin": {
+                  "type": "number",
+                  "description": "The cumulative total of the pages read from disk. Sudden high variations on this number can indicate short duration spikes in swap usage. The other memory related metrics are point in time snapshots and can miss short spikes.",
+                  "minimum": 0
+                },
+                "pgpgout": {
+                  "type": "number",
+                  "description": "The cumulative total of the pages written to disk. Sudden high variations on this number can indicate short duration spikes in swap usage. The other memory related metrics are point in time snapshots and can miss short spikes.",
+                  "minimum": 0
+                },
+                "rss_mb": {
+                  "type": "number",
+                  "description": "The portion of the memory being used by the target application.",
+                  "minimum": 0
+                },
+                "swap_mb": {
+                  "type": "number",
+                  "description": "The portion of the memory stored on disk. Swap usually indicates a shortage of memory.",
+                  "minimum": 0
+                },
+                "total_mb": {
+                  "type": "number",
+                  "description": "The sum of the rss, cache, and swap that equals the total memory being used.",
+                  "minimum": 0
+                }
+              }
             }
           }
         },


### PR DESCRIPTION
This moves the `cpu_sample` and `memory_sample` to be sub documents of the `resource_sample` event. It also adds `resource_sample.database`. Since these can co-exist they need to be grouped under the same event. I want to avoid a single log line representing multiple events.