### PR TITLE
Add cache sample type

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -517,9 +517,32 @@
                 }
               }
             },
+            "cache": {
+              "type": "object",
+              "description": "A sample of cache statistics and state.",
+              "required": ["db_size", "active_connections"],
+              "additionalProperties": false,
+              "properties": {
+                "active_connections": {
+                  "type": "integer",
+                  "description": "The number of active connections established with the database.",
+                  "minimum": 0
+                },
+                "index_cache_hit_rate": {
+                  "type": "number",
+                  "description": "The ratio of successful reads out of all read operations.",
+                  "minimum": 0
+                },
+                "evicted_keys": {
+                  "type": "integer",
+                  "description": "The number of evicted keys.",
+                  "minimum": 0
+                }
+              }
+            },
             "database": {
               "type": "object",
-              "description": "A sample of various database and local data server statistics.",
+              "description": "A sample of database statistics and state.",
               "required": ["db_size", "active_connections"],
               "additionalProperties": false,
               "properties": {


### PR DESCRIPTION
Adds sample types for caches (redis). Structures [Heroku redis log metrics](https://devcenter.heroku.com/articles/heroku-redis-metrics-logs#redis-instance-metrics).