### PR TITLE
Add high-level request details into http_response events

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -504,6 +504,25 @@
             },
             "time_ms": {
               "$ref": "#/definitions/time_ms"
+            },
+            "request": {
+              "type": "object",
+              "description": "The request being responded to. This couples the request data with the response event avoiding the need for joins or external data dependencies. In many cases the data must be coupled with this event because it is represented as a single event (nginx, apache web server, and other reverse proxy servers).",
+              "minProperties": 1,
+              "properties": {
+                "host": {
+                  "$ref": "#/definitions/http_host"
+                },
+                "method": {
+                  "$ref": "#/definitions/http_method"
+                },
+                "path": {
+                  "$ref": "#/definitions/http_path"
+                },
+                "scheme": {
+                  "$ref": "#/definitions/http_scheme"
+                }
+              }
             }
           }
         },


### PR DESCRIPTION
This adds high-level request details, such as the `host`, `method`, `path`, and `scheme` to the `http_response` event. This allows the `http_response` event to act independently, making it possible to report on response data with request filters without being dependent on other data structures. For example, in the context of Nginx, or any reverse proxy, only the request and response are combined into a single event. In reality this is just a response event with request level details. This schema change properly supports those events.

@DavidAntaramian care to give your thoughts on this?