### PR TITLE
Remove email format checking

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -328,7 +328,6 @@
             "email": {
               "type": "string",
               "description": "An email address for the user. This need not be unique to the user. Note that no validation is performed on this field.",
-              "format": "email",
               "minLength": 1,
               "maxLength": 256
             },


### PR DESCRIPTION
This removes the email format checking. This really isn't necessary and it fails for valid emails that are using new TLDs.