### PR TITLE
Remove the `tags` field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Removed
+
+  - Removed the `tags` field in favor of using the `context`, `event`, or `meta` keys which offer
+    a structured and more descriptive alternative to attaching data to a log line.
+
 ## [3.2.0] - 2017-10-23
 
 ### Added

--- a/schema.json
+++ b/schema.json
@@ -26,15 +26,6 @@
       "description": "The raw log event message, formatting stripped.",
       "maxLength": 8192
     },
-    "tags": {
-      "type": "array",
-      "description": "An array of tags to be associated with this log line.",
-      "minItems": 1,
-      "maxItems": 20,
-      "items": {
-        "type": "string"
-      }
-    },
     "time_ms": {
       "$ref": "#/definitions/time_ms"
     },


### PR DESCRIPTION
This removes the `tags` field in in favor of using the `context`, `event`, or `meta` keys which offer a structured and more descriptive alternative to attaching data to a log line.

The `tags` field was meant as way to capture tags via the [Rails tagged logging feature](http://api.rubyonrails.org/classes/ActiveSupport/TaggedLogging.html). Tags are a workaround to properly structured logs, and we felt it necessary to pull them out of the log messages and store them separately in a `tags` field. This introduced a variety of complications including confusing users as to why their tags were no longer working. We are not taking the stance that tags should be left in the message and it is the user's responsibility to adjust their application's tag configuration or the log format within the Timber console.