### PR TITLE
Bump maxLength of the function

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -533,7 +533,7 @@
                     "type": "string",
                     "description": "The calling function name.",
                     "minLength": 1,
-                    "maxLength": 256
+                    "maxLength": 1024
                   },
                   "line": {
                     "type": "integer",


### PR DESCRIPTION
Effectively allow longer function names.

In Elixir, it's vital to be able to see what exact arguments were passed to the function that caused the error. For example in case with passing maps, it's too easy to exceeds the 256 bytes limit for simple cases like this:.

```
MyApp.MyModule.MySubmodule.update("10eccdfc-73c8-493d-8db8-940b445f4753", %{"attachments" => [], "company_logo_url" => "https://s3.eu-central-1.amazonaws.com/my-bucket/uploads/9c7ed88d-8f04-4fdd-a3ce-78ad158df774/storage/2a18abee-f0f7-4402-158e-43e1f6fd9698/preview/my-preview-007.png", "fields" = (truncated)
```

Increasing the function name length 4x will allow more function definitions to be reported without truncation.